### PR TITLE
Added info about permissions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,39 @@ Use this instead of `MVMT` in future steps.
 ```
 conda create -n MVMT python=3.9 -y
 conda activate MVMT
+```
 
-#If you haven't already, install [poetry](https://python-poetry.org/docs/). Now use this to install the majority of dependencies.
-#For some reason, poetry may not work if it's not in a graphical session. I think some form of authentication token is managed differently.
+You could run into issues when installing dependencies. Check that your executable permissions are valid by running python and python3.9
+
+```
+python
+python3.9
+```
+
+If you get a permission denied error, find the location of the python executable inside of your environment that you want to change using the following command:
+
+```
+which python
+```
+
+Use the output and change the permissions using chmod.
+
+```
+# What the command should look like: 
+sudo chmod ugo+rwx <CONDA ENV LOCATION>/bin/python3.9
+```
+
+If you haven't already, install [poetry](https://python-poetry.org/docs/). Now use this to install the majority of dependencies.
+
+For some reason, poetry may not work if it's not in a graphical session. I think some form of authentication token is managed differently.
+
+```
 poetry install
+```
 
-#Now install the `pytorch3d` dependencies that can't be installed with `poetry`.
+Now install the `pytorch3d` dependencies that can't be installed with `poetry`.
+
+```
 conda install pytorch=1.13.0 torchvision pytorch-cuda=11.6 -c pytorch -c nvidia -y
 conda install -c fvcore -c iopath -c conda-forge fvcore iopath -y
 conda install -c bottler nvidiacub -y

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ conda create -n MVMT python=3.9 -y
 conda activate MVMT
 ```
 
-You could run into issues when installing dependencies. Check that your executable permissions are valid by running python and python3.9
+For internal collaborators working on /ofo-share, you could run into issues when installing dependencies. Check that your executable permissions are valid by running python and python3.9.
 
 ```
 python
@@ -135,10 +135,14 @@ Use the output and change the permissions using chmod.
 
 ```
 # What the command should look like: 
-sudo chmod ugo+rwx <CONDA ENV LOCATION>/bin/python3.9
+chmod ugo+x <CONDA ENV LOCATION>/bin/python3.9
 ```
 
 If you haven't already, install [poetry](https://python-poetry.org/docs/). Now use this to install the majority of dependencies.
+
+```
+curl -sSL https://install.python-poetry.org | python3 -
+```
 
 For some reason, poetry may not work if it's not in a graphical session. I think some form of authentication token is managed differently.
 


### PR DESCRIPTION
Closes #80 . The README now includes info on how to find the environment's python path and how to change permissions to execute if they are denied after a user creates a new conda environment. 