### PR TITLE
Classify polygons from face predictions

### DIFF
--- a/multiview_mapping_toolkit/constants.py
+++ b/multiview_mapping_toolkit/constants.py
@@ -17,6 +17,7 @@ VIS_FOLDER = Path(Path(__file__).parent, "..", "vis").resolve()
 VERT_ID = "vert_ID"
 CLASS_ID_KEY = "class_ID"
 CLASS_NAMES_KEY = "class_names"
+RATIO_3D_2D_KEY = "ratio_3d_2d"
 NULL_TEXTURE_FLOAT_VALUE = -1
 NULL_TEXTURE_INT_VALUE = 255
 LAT_LON_EPSG_CODE = pyproj.CRS.from_epsg(4326)


### PR DESCRIPTION
This allows the mesh object to classify polygons based on the most common class, as predicted per-face, and weighted by face area. It currently only supports single-ID-per-face, but could be extended to take the distribution of ID predictions.

It could be accelerated by #82 , but I'd prefer to get it in before implementing that.  